### PR TITLE
Modified Course Configuration so that the type of attendance may be c…

### DIFF
--- a/src/main/java/edu/ksu/canvas/aviation/entity/AviationCourse.java
+++ b/src/main/java/edu/ksu/canvas/aviation/entity/AviationCourse.java
@@ -1,5 +1,6 @@
 package edu.ksu.canvas.aviation.entity;
 
+import edu.ksu.canvas.aviation.enums.AttendanceType;
 import org.hibernate.annotations.Check;
 
 import javax.persistence.*;
@@ -24,18 +25,23 @@ public class AviationCourse implements Serializable {
     @Column(name = "default_minutes_per_session")
     private Integer defaultMinutesPerSession;
 
+    @Column(name = "attendance_type", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private AttendanceType attendanceType;
+
     @Column(name = "canvas_course_id", nullable = false, unique = true)
     private Long canvasCourseId;
 
 
     public AviationCourse() {
-
+        this.attendanceType = AttendanceType.SIMPLE;
     }
 
     public AviationCourse(Long canvasCourseId, int totalClassMinutes, int defaultMinutesPerSession) {
         this.canvasCourseId = canvasCourseId;
         this.totalMinutes = totalClassMinutes;
         this.defaultMinutesPerSession = defaultMinutesPerSession;
+        this.attendanceType = AttendanceType.SIMPLE;
     }
 
 
@@ -78,4 +84,11 @@ public class AviationCourse implements Serializable {
                 + defaultMinutesPerSession + ", canvasCourseId=" + canvasCourseId + "]";
     }
 
+    public AttendanceType getAttendanceType() {
+        return attendanceType;
+    }
+
+    public void setAttendanceType(AttendanceType attendanceType) {
+        this.attendanceType = attendanceType;
+    }
 }

--- a/src/main/java/edu/ksu/canvas/aviation/enums/AttendanceType.java
+++ b/src/main/java/edu/ksu/canvas/aviation/enums/AttendanceType.java
@@ -1,0 +1,5 @@
+package edu.ksu.canvas.aviation.enums;
+
+public enum AttendanceType {
+    SIMPLE, MINUTES
+}

--- a/src/main/java/edu/ksu/canvas/aviation/form/CourseConfigurationForm.java
+++ b/src/main/java/edu/ksu/canvas/aviation/form/CourseConfigurationForm.java
@@ -14,6 +14,8 @@ public class CourseConfigurationForm {
     @Min(1)
     private int defaultMinutesPerSession;
 
+    private Boolean simpleAttendance;
+
 
     public int getTotalClassMinutes() {
         return totalClassMinutes;
@@ -31,4 +33,11 @@ public class CourseConfigurationForm {
         this.defaultMinutesPerSession = defaultMinutesPerSession;
     }
 
+    public void setSimpleAttendance(boolean simpleAttendance) {
+        this.simpleAttendance = simpleAttendance;
+    }
+
+    public Boolean getSimpleAttendance() {
+        return simpleAttendance;
+    }
 }

--- a/src/main/java/edu/ksu/canvas/aviation/services/AviationCourseService.java
+++ b/src/main/java/edu/ksu/canvas/aviation/services/AviationCourseService.java
@@ -1,5 +1,6 @@
 package edu.ksu.canvas.aviation.services;
 
+import edu.ksu.canvas.aviation.enums.AttendanceType;
 import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.exception.ContextedRuntimeException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,6 +30,12 @@ public class AviationCourseService {
         } else {
             aviationCourse.setDefaultMinutesPerSession(courseForm.getDefaultMinutesPerSession());
             aviationCourse.setTotalMinutes(courseForm.getTotalClassMinutes());
+            if (courseForm.getSimpleAttendance() != null && courseForm.getSimpleAttendance()) {
+                aviationCourse.setAttendanceType(AttendanceType.SIMPLE);
+            }
+            else {
+                aviationCourse.setAttendanceType(AttendanceType.MINUTES);
+            }
         }
 
         aviationCourseRepository.save(aviationCourse);
@@ -50,6 +57,7 @@ public class AviationCourseService {
 
         courseForm.setTotalClassMinutes(aviationCourse.getTotalMinutes());
         courseForm.setDefaultMinutesPerSession(aviationCourse.getDefaultMinutesPerSession());
+        courseForm.setSimpleAttendance(aviationCourse.getAttendanceType().equals(AttendanceType.SIMPLE));
     }
 
 }

--- a/src/main/webapp/WEB-INF/jsp/courseConfiguration.jsp
+++ b/src/main/webapp/WEB-INF/jsp/courseConfiguration.jsp
@@ -85,6 +85,12 @@
                                 cssClass="form-control" placeholder="Normal Class Length" size="5"/>
                     <form:errors cssClass="error center-block" path="defaultMinutesPerSession"/>
                 </div>
+                <div class="col-md-3">
+                    <label for="simpleAttendance">
+                    <form:checkbox path="simpleAttendance" id="simpleAttendance" cssClass="form-control"/> Use Simple Attendance (non-minute based) features
+                    </label>
+                </div>
+
             </fieldset>
         </div>
         <input value="Save Class Minutes" id="saveCourseConfiguration" name="saveCourseConfiguration"

--- a/src/test/java/edu/ksu/canvas/aviation/controller/CourseConfigurationControllerITest.java
+++ b/src/test/java/edu/ksu/canvas/aviation/controller/CourseConfigurationControllerITest.java
@@ -1,5 +1,6 @@
 package edu.ksu.canvas.aviation.controller;
 
+import edu.ksu.canvas.aviation.enums.AttendanceType;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -44,6 +45,7 @@ public class CourseConfigurationControllerITest extends BaseControllerITest {
         existingCourse.setCanvasCourseId(2000L);
         existingCourse.setDefaultMinutesPerSession(10);
         existingCourse.setTotalMinutes(SynchronizationService.DEFAULT_TOTAL_CLASS_MINUTES);
+        existingCourse.setAttendanceType(AttendanceType.SIMPLE);
         existingCourse = courseRepository.save(existingCourse);
         
         existingSection = new AviationSection();
@@ -88,17 +90,40 @@ public class CourseConfigurationControllerITest extends BaseControllerITest {
         Long irrlevantSectionId = 3000L;
         Integer expectedDefaultMinutesPerSession = 100;
         Integer expectedTotalClassMinutes = 1000;
+        Boolean expectedSimpleAttendanceValue = true;
         
         mockMvc.perform(post("/courseConfiguration/"+irrlevantSectionId+"/save")
+                .param("saveCourseConfiguration", "Save Course Configuration")
+                .param("defaultMinutesPerSession", String.valueOf(expectedDefaultMinutesPerSession))
+                .param("totalClassMinutes", String.valueOf(expectedTotalClassMinutes))
+                .param("simpleAttendance", String.valueOf(expectedSimpleAttendanceValue)))
+                .andExpect(status().isOk())
+                .andExpect(view().name("forward:/courseConfiguration/" + irrlevantSectionId + "?updateSuccessful=true"));
+        
+        AviationCourse course = courseRepository.findByCourseId(existingCourse.getCourseId());
+        assertEquals(expectedDefaultMinutesPerSession, course.getDefaultMinutesPerSession());
+        assertEquals(expectedTotalClassMinutes, course.getTotalMinutes());
+        assertEquals(expectedSimpleAttendanceValue, course.getAttendanceType().equals(AttendanceType.SIMPLE));
+    }
+
+    @Test
+    public void saveCourseConfiguration_MinuteBasedAttendance() throws Exception {
+        Long irrlevantSectionId = 3000L;
+        Integer expectedDefaultMinutesPerSession = 100;
+        Integer expectedTotalClassMinutes = 1000;
+        Boolean expectedSimpleAttendanceValue = true;
+
+        mockMvc.perform(post("/courseConfiguration/" + irrlevantSectionId + "/save")
                 .param("saveCourseConfiguration", "Save Course Configuration")
                 .param("defaultMinutesPerSession", String.valueOf(expectedDefaultMinutesPerSession))
                 .param("totalClassMinutes", String.valueOf(expectedTotalClassMinutes)))
                 .andExpect(status().isOk())
                 .andExpect(view().name("forward:/courseConfiguration/"+irrlevantSectionId+"?updateSuccessful=true"));
-        
+
         AviationCourse course = courseRepository.findByCourseId(existingCourse.getCourseId());
         assertEquals(expectedDefaultMinutesPerSession, course.getDefaultMinutesPerSession());
         assertEquals(expectedTotalClassMinutes, course.getTotalMinutes());
+        assertEquals(expectedSimpleAttendanceValue, course.getAttendanceType().equals(AttendanceType.MINUTES));
     }
     
     @Test

--- a/src/test/java/edu/ksu/canvas/aviation/services/AviationCourseServiceUTest.java
+++ b/src/test/java/edu/ksu/canvas/aviation/services/AviationCourseServiceUTest.java
@@ -1,5 +1,6 @@
 package edu.ksu.canvas.aviation.services;
 
+import edu.ksu.canvas.aviation.enums.AttendanceType;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -72,6 +73,7 @@ public class AviationCourseServiceUTest {
         long nonExistantCanvasCourseId = -1;
         Integer expectedTotalClassMinutes = 500;
         Integer expectedDefaultMinutesPerSession = 45;
+        AttendanceType expectedDefaultType = AttendanceType.SIMPLE;
         CourseConfigurationForm courseForm = new CourseConfigurationForm();
         courseForm.setDefaultMinutesPerSession(expectedDefaultMinutesPerSession);
         courseForm.setTotalClassMinutes(expectedTotalClassMinutes);
@@ -83,13 +85,15 @@ public class AviationCourseServiceUTest {
         verify(mockCourseRepository, atLeastOnce()).save(capturedAviationCourse.capture());
         assertEquals("expectedTotalClassMinutes", capturedAviationCourse.getValue().getTotalMinutes(), expectedTotalClassMinutes);
         assertEquals("expectedDefaultMinutesPerSession", capturedAviationCourse.getValue().getDefaultMinutesPerSession(), expectedDefaultMinutesPerSession);
+        assertEquals("expectedDefaultAttendanceType", capturedAviationCourse.getValue().getAttendanceType(), expectedDefaultType);
     }
     
     @Test
-    public void save_ExistingCourse() {
+    public void save_ExistingCourseMinutesAttendance() {
         long nonExistantCanvasCourseId = -1;
         Integer expectedTotalClassMinutes = 500;
         Integer expectedDefaultMinutesPerSession = 45;
+        AttendanceType expectedAttendanceType = AttendanceType.MINUTES;
         CourseConfigurationForm courseForm = new CourseConfigurationForm();
         courseForm.setDefaultMinutesPerSession(expectedDefaultMinutesPerSession);
         courseForm.setTotalClassMinutes(expectedTotalClassMinutes);
@@ -99,8 +103,32 @@ public class AviationCourseServiceUTest {
         courseService.save(courseForm, nonExistantCanvasCourseId);
         
         verify(mockCourseRepository, atLeastOnce()).save(existingCourse);
-        assertEquals("expectedTotalClassMinutes", existingCourse.getTotalMinutes(), expectedTotalClassMinutes);
-        assertEquals("expectedDefaultMinutesPerSession", existingCourse.getDefaultMinutesPerSession(), expectedDefaultMinutesPerSession);
+        assertEquals("expectedTotalClassMinutes", expectedTotalClassMinutes, existingCourse.getTotalMinutes());
+        assertEquals("expectedDefaultMinutesPerSession", expectedDefaultMinutesPerSession, existingCourse.getDefaultMinutesPerSession());
+        assertEquals("expectedAttendanceType", expectedAttendanceType, existingCourse.getAttendanceType());
+
+    }
+
+    @Test
+    public void save_ExistingCourseSimpleAttendance() {
+        long nonExistantCanvasCourseId = -1;
+        Integer expectedTotalClassMinutes = 500;
+        Integer expectedDefaultMinutesPerSession = 45;
+        AttendanceType expectedAttendanceType = AttendanceType.SIMPLE;
+        CourseConfigurationForm courseForm = new CourseConfigurationForm();
+        courseForm.setDefaultMinutesPerSession(expectedDefaultMinutesPerSession);
+        courseForm.setTotalClassMinutes(expectedTotalClassMinutes);
+        courseForm.setSimpleAttendance(true);
+        AviationCourse existingCourse = new AviationCourse();
+
+        when(mockCourseRepository.findByCanvasCourseId(nonExistantCanvasCourseId)).thenReturn(existingCourse);
+        courseService.save(courseForm, nonExistantCanvasCourseId);
+
+        verify(mockCourseRepository, atLeastOnce()).save(existingCourse);
+        assertEquals("expectedTotalClassMinutes", expectedTotalClassMinutes, existingCourse.getTotalMinutes());
+        assertEquals("expectedDefaultMinutesPerSession", expectedDefaultMinutesPerSession, existingCourse.getDefaultMinutesPerSession());
+        assertEquals("expectedAttendanceType", expectedAttendanceType, existingCourse.getAttendanceType());
+
     }
     
     @Test(expected = NullPointerException.class)


### PR DESCRIPTION
…hosen

Currently, choosing which type of attendance the course has does not do anything other than mark a checkbox.
In the future, it will change the report functionality, as well as the display of certain pages
Defaults to "simple" attendance (e.g. Present, Tardy, Absent with no tracking of minutes)
