### PR TITLE
Fixed Delete and Push functionality

### DIFF
--- a/src/main/java/edu/ksu/canvas/attendance/controller/CourseConfigurationController.java
+++ b/src/main/java/edu/ksu/canvas/attendance/controller/CourseConfigurationController.java
@@ -167,7 +167,7 @@ public class CourseConfigurationController extends AttendanceBaseController {
         return assignmentConfigurationFromSetup;
     }
 
-    @RequestMapping(value = "/{sectionId}/delete", method = RequestMethod.POST)
+    @RequestMapping(value = "/{sectionId}/save", params = "deleteAssignment", method = RequestMethod.POST)
     public ModelAndView deleteAttendanceAssignment(@PathVariable String sectionId) throws NoLtiSessionException {
         LOG.info("eid: " + canvasService.getEid() + " is turning off grading feature and deleting the assignment from Canvas for section: " + sectionId);
         ModelAndView page = new ModelAndView("forward:/courseConfiguration/" + sectionId);

--- a/src/main/webapp/WEB-INF/jsp/courseConfiguration.jsp
+++ b/src/main/webapp/WEB-INF/jsp/courseConfiguration.jsp
@@ -57,26 +57,6 @@
         <div class="alert alert-success" id="pushingSuccessful">
             <p>Pushing attendance grades to Canvas successful.</p>
         </div>
-
-        <div class="confirmation-modal modal fade" id = "pushConfirmation">
-            <div class="modal-dialog">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <button type="button" class="close" onclick="hidePushingAlert()">&times;</button>
-                        <h4 class="modal-title">Push Confirmation</h4>
-                    </div>
-                    <div class="modal-body">
-                        Please allow a few minutes for Canvas to update the gradebook.
-                    </div>
-                    <div class="modal-footer">
-                        <button class="confirm btn btn-primary" type="button" onclick="hidePushingAlert()">
-                            OK
-                        </button>
-                    </div>
-                </div>
-            </div>
-        </div>
-
     </c:if>
 <!--There needs to be a message that returns a list of sections that did not successfully push grades to Canvas. It should be grouped with the following success messages. -->
     <c:if test="${updateSuccessful}">
@@ -152,7 +132,9 @@
 
         <div class = "container-fluid ${courseConfigurationForm.gradingOn? '' : 'hidden'}" id="conversionConfig" >
             <br/>
-            <label> NOTE: When this assignment is pushed to the gradebook, it will immediately be published. Please do not alter the assignment in the gradebook, but instead use this application to update the assignment as needed.
+            <label> NOTE: When this assignment is pushed to the gradebook, it will immediately be published.
+                Please do not alter the assignment in the gradebook, but instead use this application to update the assignment as needed.
+                Click the "Conver Attendance to Assignment" checkbox again to remove the assignment.
             </label>
             <br/>
             <div class="col-md-2 col-md-offset-0">
@@ -205,18 +187,55 @@
 
         </div>
 
+
         <input value="Save Setup" id="saveCourseConfiguration" name="saveCourseConfiguration"
                class="hovering-purple-button pull-left buffer-top" type="submit"/>
-        <input value="Push Assignment to Canvas" id="pushGradesToCanvas" name="pushGradesToCanvas"
-               class="hovering-purple-button pull-right buffer-top ${courseConfigurationForm.gradingOn? '' : 'hidden'}" type="submit"/>
+        <input value="Push Assignment to Canvas" id="pushConfirmation" name="pushConfirmation"
+               class="hovering-purple-button pull-right buffer-top ${courseConfigurationForm.gradingOn? '' : 'hidden'}" type="button" onclick="$('#pushModal').modal('show')"/>
     </div>
     <hr/>
+
+    <div class="confirmation-modal modal fade in" id = "deleteModal">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" onclick="$('#deleteModal').modal('hide')">&times;</button>
+                    <h4 class="modal-title">Deletion Confirmation</h4>
+                </div>
+                <div class="modal-body">
+                    Turning off the grading feature will delete the Attendance Assignment from Canvas. Do you want to continue?
+                </div>
+                <div class="modal-footer">
+                    <input value="Yes" id="deleteAssignment" name="deleteAssignment" class="confirm btn btn-primary" type="submit">
+                    </input>
+                    <button class="confirm btn btn-default" type="button" onclick="$('#deleteModal').modal('hide')">
+                        No
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="confirmation-modal modal fade in" id = "pushModal">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" onclick="$('#pushModal').hide()">&times;</button>
+                    <h4 class="modal-title">Push Confirmation</h4>
+                </div>
+                <div class="modal-body">
+                    Please allow a few minutes for Canvas to update the gradebook.
+                </div>
+                <div class="modal-footer">
+                    <input value="OK" id="pushGradesToCanvas" name="pushGradesToCanvas" class="confirm btn btn-primary" type="submit">
+                    </input>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <br/><br/>
     <script>
-
-        $(document).ready(function(){
-            $('#pushConfirmation').modal('show');
-        });
 
         var errorMessage = "There was an error communicating with the server.";
 
@@ -233,36 +252,16 @@
 
         $('#conversionConfirm').change(function(){
             if (this.checked) {
-                $('#pushGradesToCanvas').removeClass('hidden');
+                $('#pushConfirmation').removeClass('hidden');
                 $('#conversionConfig').removeClass('hidden');
             } else {
-                $('#pushGradesToCanvas').addClass('hidden');
+                $('#pushConfirmation').addClass('hidden');
                 $('#conversionConfig').addClass('hidden');
                 if(hasAssignmentConfiguration()) {
-                    confirmChoice('Turning off the grading feature will delete the Attendance Assignment from Canvas. Do you want to continue?', 'Delete Assignment Confirmation');
+                    $('#deleteModal').modal('show');
                 }
             }
         });
-
-        function hidePushingAlert (){
-            $('#pushConfirmation').modal('hide');
-        }
-
-        function confirmChoice(msg, title) {
-            $.confirm({
-                text: msg,
-                title: title,
-                cancelButton: "No",
-                confirm: function() {
-                    var form = $('sectionSelect');
-                    form.action = "<c:url value="/courseConfiguration/${selectedSectionId}/delete"/>";
-                    form.submit();
-                },
-                cancel: function(){
-                   location.reload();
-                }
-            });
-        }
 
         function hasAssignmentConfiguration() {
             if($('#assignmentName').length == 0 || $('#assignmentPoints').length == 0 ) {

--- a/src/test/java/edu/ksu/canvas/attendance/controller/CourseConfigurationControllerITest.java
+++ b/src/test/java/edu/ksu/canvas/attendance/controller/CourseConfigurationControllerITest.java
@@ -210,7 +210,8 @@ public class CourseConfigurationControllerITest extends BaseControllerITest {
     public void deleteAttendanceAssignment_HappyPath() throws Exception {
         Long irrelevantSectionId = 3000L;
 
-        mockMvc.perform(post("/courseConfiguration/"+irrelevantSectionId+"/delete"))
+        mockMvc.perform(post("/courseConfiguration/"+irrelevantSectionId+"/save")
+                .param("deleteAssignment", "Yes"))
                 .andExpect(status().isOk())
                 .andExpect(model().attribute("deleteSuccessful", is(true)))
                 .andExpect(view().name("forward:/courseConfiguration/" + irrelevantSectionId));


### PR DESCRIPTION
When testing, I realized that the Course Configuration form was not properly submitting and was causing issues that stopped the Delete and Push functionality of this feature. This seems to have fixed that issue.