### PR TITLE
Fixed Synchronization bug and associated Unit tests

### DIFF
--- a/src/main/java/edu/ksu/canvas/attendance/services/SynchronizationService.java
+++ b/src/main/java/edu/ksu/canvas/attendance/services/SynchronizationService.java
@@ -114,29 +114,27 @@ public class SynchronizationService {
 
     private List<AttendanceStudent> synchronizeStudentsFromCanvasToDb(Map<Section, List<Enrollment>> canvasSectionMap, boolean hasOneAuthorityRole) {
         List<AttendanceStudent> ret = new ArrayList<>();
-        List<AttendanceStudent> existingStudentsInDb = null;
-        Set<AttendanceStudent> droppedStudents = new HashSet<>();
 
         for(Section section: canvasSectionMap.keySet()) {
-
-            if(existingStudentsInDb == null) {
-                existingStudentsInDb = studentRepository.findByCanvasCourseId(section.getCourseId());
-                droppedStudents.addAll(existingStudentsInDb);
-            }
+            Set<AttendanceStudent> droppedStudents = new HashSet<>();
+            List<AttendanceStudent> existingStudentsInDb;
+            existingStudentsInDb = studentRepository.findByCanvasSectionIdOrderByNameAsc(section.getId());
+            droppedStudents.addAll(existingStudentsInDb);
 
             for(Enrollment enrollment: canvasSectionMap.get(section)) {
 
                 Optional<AttendanceStudent> foundUser =
                         existingStudentsInDb.stream()
                                         .filter(u -> u.getSisUserId().equals(enrollment.getUser().getSisUserId()))
+                                        .limit(1)
                                         .findFirst();
 
                 if (foundUser.isPresent()){
                     droppedStudents.remove(foundUser.get());
+                    foundUser.get().setDeleted(Boolean.FALSE);
                 }
                 AttendanceStudent student = foundUser.isPresent() ? foundUser.get() : new AttendanceStudent();
                 student = setStudentInfo(student, enrollment, section);
-                student.setDeleted(foundUser.isPresent() ? foundUser.get().getDeleted() : Boolean.FALSE);
 
                 if (student.getAttendances() == null) {
                     List<Attendance> attendances = new ArrayList<>();
@@ -151,9 +149,10 @@ public class SynchronizationService {
                 }
 
             }
-
+            droppedStudents.forEach(c -> c.setDeleted(Boolean.TRUE));
+            addDroppedStudents(ret, droppedStudents);
         }
-        addDroppedStudents(ret, droppedStudents);
+
 
         return ret;
     }

--- a/src/main/java/edu/ksu/canvas/attendance/services/SynchronizationService.java
+++ b/src/main/java/edu/ksu/canvas/attendance/services/SynchronizationService.java
@@ -117,8 +117,7 @@ public class SynchronizationService {
 
         for(Section section: canvasSectionMap.keySet()) {
             Set<AttendanceStudent> droppedStudents = new HashSet<>();
-            List<AttendanceStudent> existingStudentsInDb;
-            existingStudentsInDb = studentRepository.findByCanvasSectionIdOrderByNameAsc(section.getId());
+            List<AttendanceStudent> existingStudentsInDb = studentRepository.findByCanvasSectionIdOrderByNameAsc(section.getId());
             droppedStudents.addAll(existingStudentsInDb);
 
             for(Enrollment enrollment: canvasSectionMap.get(section)) {
@@ -133,7 +132,7 @@ public class SynchronizationService {
                     droppedStudents.remove(foundUser.get());
                     foundUser.get().setDeleted(Boolean.FALSE);
                 }
-                AttendanceStudent student = foundUser.isPresent() ? foundUser.get() : new AttendanceStudent();
+                AttendanceStudent student = foundUser.orElse(new AttendanceStudent());
                 student = setStudentInfo(student, enrollment, section);
 
                 if (student.getAttendances() == null) {


### PR DESCRIPTION
Just for clarification, the test was removed because it was not testing the case it was created for. The application was passing this test before because the the synchronization method was broken, so while the method was returning the wrong data, the data was in line with what the test was asserting, allowing it to pass. Another test may need to be created later.