### PR TITLE
Run Integration and Arquillian tests with failsafe

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,10 @@
 					</execute-commands>
 				</configuration>
 			</plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
         </plugins>
 
         <pluginManagement>
@@ -120,6 +124,44 @@
                         </lifecycleMappingMetadata>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.19.1</version>
+                    <configuration>
+                        <classpathDependencyExcludes>
+                            <!-- avoid sl4j warning-->
+                            <classpathDependencyExclude>ch.qos.logback:logback-classic</classpathDependencyExclude>
+                        </classpathDependencyExcludes>
+                        <includes>
+                            <include>**/*UTest.java</include>
+                        </includes>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <configuration>
+                        <includes>
+                            <include>**/*ITest.java</include>
+                        </includes>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <phase>integration-test</phase>
+                            <goals>
+                                <goal>integration-test</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>verify</id>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>verify</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>
@@ -131,26 +173,6 @@
           <activation>
               <activeByDefault>true</activeByDefault>
           </activation>
-          <build>
-              <pluginManagement>
-                <plugins>
-	                <plugin>
-	                   <groupId>org.apache.maven.plugins</groupId>
-	                   <artifactId>maven-surefire-plugin</artifactId>
-	                   <version>2.19.1</version>
-	                   <configuration>
-	                      <classpathDependencyExcludes>
-	                          <!-- avoid sl4j warning-->
-	                          <classpathDependencyExclude>ch.qos.logback:logback-classic</classpathDependencyExclude>
-	                      </classpathDependencyExcludes>
-				          <excludes>
-				            <exclude>**/*ArquillianTest.java</exclude>
-				          </excludes>
-	                  </configuration>
-	               </plugin>
-                </plugins>
-              </pluginManagement>
-          </build>
         </profile>
 
 		<profile>
@@ -278,21 +300,26 @@
                             </execution>
                         </executions>
                     </plugin>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-surefire-plugin</artifactId>
-						<inherited>false</inherited>
-						<configuration>
-							<systemPropertyVariables>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
                                 <arquillian.launch>jboss-managed</arquillian.launch>
                                 <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-								<jboss.home>${jboss.home}</jboss.home>
+                                <jboss.home>${jboss.home}</jboss.home>
                                 <jboss.port.offset>${jboss.port.offset}</jboss.port.offset>
-								<arquillian.startup.timeout>${arquillian.startup.timeout}</arquillian.startup.timeout>
-								<arquillian.debug>false</arquillian.debug>
-							</systemPropertyVariables>
+                                <arquillian.startup.timeout>${arquillian.startup.timeout}</arquillian.startup.timeout>
+                                <arquillian.debug>false</arquillian.debug>
+                            </systemPropertyVariables>
+                            <skipTests>true</skipTests>
+                        </configuration>
+                    </plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-failsafe-plugin</artifactId>
+						<configuration>
 							<includes>
-								<include>%regex[.*ArquillianTest.*]</include>
+								<include>**/*ArquillianTest.java</include>
 							</includes>
 						</configuration>
 					</plugin>


### PR DESCRIPTION
Surefire should only be used to run unit tests.

I added failsafe and fixed the maven profiles so that the integration
and arquillian tests can each be run without running the unit tests.