### PR TITLE
updating lti-launch version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -549,7 +549,7 @@
         <dependency>
             <groupId>edu.ksu.ome.lti</groupId>
             <artifactId>lti-launch</artifactId>
-            <version>1.4.0</version>
+            <version>1.4.1</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>


### PR DESCRIPTION
1.4.1 depends on a new version of spring-security-oauth 2.0.17 instead of 2.0.2