### PR TITLE
Remove hbm2ddl property for auto-configuration

### DIFF
--- a/src/main/java/edu/ksu/canvas/attendance/config/PersistenceConfig.java
+++ b/src/main/java/edu/ksu/canvas/attendance/config/PersistenceConfig.java
@@ -58,7 +58,6 @@ public class PersistenceConfig {
 
     Properties additionalProperties() {
         Properties properties = new Properties();
-        properties.setProperty("hibernate.hbm2ddl.auto", "update");
         properties.setProperty("hibernate.dialect", "org.hibernate.dialect.Oracle10gDialect");
         return properties;
     }


### PR DESCRIPTION
Auto-configuration property can cause issues by automatically updating database schema