### PR TITLE
fix invalid relative forward path on student summary validation fail

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -33,5 +33,10 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="src" path="target/generated-sources/annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/src/main/java/edu/ksu/canvas/attendance/controller/AttendanceBaseController.java
+++ b/src/main/java/edu/ksu/canvas/attendance/controller/AttendanceBaseController.java
@@ -98,10 +98,10 @@ public class AttendanceBaseController extends LtiLaunchController {
                         return new ModelAndView("studentSyncFailed");
                     }
                 }
-                return new ModelAndView("forward:studentSummary/"+ attendanceStudent.getCanvasSectionId().toString()+"/"+ attendanceStudent.getStudentId().toString());
+                return new ModelAndView("forward:/studentSummary/"+ attendanceStudent.getCanvasSectionId().toString()+"/"+ attendanceStudent.getStudentId().toString());
             }
         }
-        return new ModelAndView("forward:roster");
+        return new ModelAndView("forward:/roster");
     }
 
     protected AttendanceSection getSelectedSection(Long previousSelectedSectionId) throws NoLtiSessionException {

--- a/src/main/java/edu/ksu/canvas/attendance/controller/AttendanceSummaryController.java
+++ b/src/main/java/edu/ksu/canvas/attendance/controller/AttendanceSummaryController.java
@@ -57,7 +57,7 @@ public class AttendanceSummaryController extends AttendanceBaseController {
 
         Long validatedSectionId = LongValidator.getInstance().validate(sectionId);
         if (validatedSectionId == null) {
-            return new ModelAndView("forward:roster");
+            return new ModelAndView("forward:/roster");
         }
 
         AttendanceSection selectedSection = getSelectedSection(validatedSectionId);

--- a/src/main/java/edu/ksu/canvas/attendance/controller/CourseConfigurationController.java
+++ b/src/main/java/edu/ksu/canvas/attendance/controller/CourseConfigurationController.java
@@ -76,7 +76,7 @@ public class CourseConfigurationController extends AttendanceBaseController {
         Long validatedSectionId = LongValidator.getInstance().validate(sectionId);
         AttendanceSection selectedSection = validatedSectionId == null ? null : getSelectedSection(validatedSectionId);
         if(validatedSectionId == null || selectedSection == null) {
-            return new ModelAndView("forward:roster");
+            return new ModelAndView("forward:/roster");
         }
 
         ModelAndView page = new ModelAndView("courseConfiguration");

--- a/src/main/java/edu/ksu/canvas/attendance/controller/MakeupController.java
+++ b/src/main/java/edu/ksu/canvas/attendance/controller/MakeupController.java
@@ -58,13 +58,13 @@ public class MakeupController extends AttendanceBaseController {
         Long validatedSectionId = LongValidator.getInstance().validate(sectionId);
         AttendanceSection selectedSection = validatedSectionId == null ? null : getSelectedSection(validatedSectionId);
         if(validatedSectionId == null || selectedSection == null) {
-            return new ModelAndView("forward:roster");
+            return new ModelAndView("forward:/roster");
         }
 
         Long validatedStudentId = LongValidator.getInstance().validate(studentId);
         AttendanceStudent selectedStudent = validatedStudentId == null ? null : studentService.getStudent(validatedStudentId);
         if(validatedStudentId == null || selectedStudent == null) {
-            return new ModelAndView("forward:roster/"+validatedSectionId);
+            return new ModelAndView("forward:/roster/"+validatedSectionId);
         }
 
         AttendanceStudent student = studentService.getStudent(new Long(studentId));

--- a/src/main/java/edu/ksu/canvas/attendance/controller/RosterController.java
+++ b/src/main/java/edu/ksu/canvas/attendance/controller/RosterController.java
@@ -109,7 +109,7 @@ public class RosterController extends AttendanceBaseController {
 
         Long validatedSectionId = LongValidator.getInstance().validate(sectionId);
         if(validatedSectionId == null) {
-            return new ModelAndView("forward:roster");
+            return new ModelAndView("forward:/roster");
         }
 
         if (bindingResult.hasErrors()) {

--- a/src/main/java/edu/ksu/canvas/attendance/controller/StudentSummaryController.java
+++ b/src/main/java/edu/ksu/canvas/attendance/controller/StudentSummaryController.java
@@ -80,13 +80,13 @@ public class StudentSummaryController extends AttendanceBaseController {
         Long validatedStudentId = LongValidator.getInstance().validate(studentId);
 
         if (validatedSectionId == null || validatedStudentId == null) {
-            return new ModelAndView("forward:roster");
+            return new ModelAndView("forward:/roster");
         }
 
         AttendanceStudent student = studentService.getStudent(validatedStudentId);
 
         if (student == null){
-            return new ModelAndView("forward:roster");
+            return new ModelAndView("forward:/roster");
 
         }
         MakeupForm makeupForm = makeupService.createMakeupForm(student.getStudentId(), validatedSectionId, addEmptyEntry);

--- a/src/test/java/edu/ksu/canvas/attendance/controller/AttendanceSummaryControllerITest.java
+++ b/src/test/java/edu/ksu/canvas/attendance/controller/AttendanceSummaryControllerITest.java
@@ -74,7 +74,7 @@ public class AttendanceSummaryControllerITest extends BaseControllerITest {
         String badSectionId = "hackerDelight";
         mockMvc.perform(get("/attendanceSummary/"+badSectionId))
             .andExpect(status().isOk())
-            .andExpect(view().name("forward:roster"));
+            .andExpect(view().name("forward:/roster"));
     }
 
     @Test

--- a/src/test/java/edu/ksu/canvas/attendance/controller/CourseConfigurationControllerITest.java
+++ b/src/test/java/edu/ksu/canvas/attendance/controller/CourseConfigurationControllerITest.java
@@ -68,7 +68,7 @@ public class CourseConfigurationControllerITest extends BaseControllerITest {
         
         mockMvc.perform(get("/courseConfiguration/"+nonExistentSectionId))
             .andExpect(status().isOk())
-            .andExpect(view().name("forward:roster"));
+            .andExpect(view().name("forward:/roster"));
     }
 
     @Test
@@ -77,7 +77,7 @@ public class CourseConfigurationControllerITest extends BaseControllerITest {
         
         mockMvc.perform(get("/courseConfiguration/"+badSectionId))
             .andExpect(status().isOk())
-            .andExpect(view().name("forward:roster"));
+            .andExpect(view().name("forward:/roster"));
     }
 
     @Test

--- a/src/test/java/edu/ksu/canvas/attendance/controller/MakeupControllerITest.java
+++ b/src/test/java/edu/ksu/canvas/attendance/controller/MakeupControllerITest.java
@@ -99,7 +99,7 @@ public class MakeupControllerITest extends BaseControllerITest {
         
         mockMvc.perform(get("/studentMakeup/"+nonNumberSectionId+"/"+studentId))
             .andExpect(status().isOk())
-            .andExpect(view().name("forward:roster"));
+            .andExpect(view().name("forward:/roster"));
     }
     
     @Test
@@ -109,7 +109,7 @@ public class MakeupControllerITest extends BaseControllerITest {
         
         mockMvc.perform(get("/studentMakeup/"+nonExistantSectionId+"/"+studentId))
             .andExpect(status().isOk())
-            .andExpect(view().name("forward:roster"));
+            .andExpect(view().name("forward:/roster"));
     }
     
     @Test
@@ -119,7 +119,7 @@ public class MakeupControllerITest extends BaseControllerITest {
         
         mockMvc.perform(get("/studentMakeup/"+sectionId+"/"+nonNumberstudentId))
             .andExpect(status().isOk())
-            .andExpect(view().name("forward:roster/"+sectionId));
+            .andExpect(view().name("forward:/roster/"+sectionId));
     }
     
     @Test
@@ -129,7 +129,7 @@ public class MakeupControllerITest extends BaseControllerITest {
         
         mockMvc.perform(get("/studentMakeup/"+sectionId+"/"+nonExistStudentId))
             .andExpect(status().isOk())
-            .andExpect(view().name("forward:roster/"+sectionId));
+            .andExpect(view().name("forward:/roster/"+sectionId));
     }
     
     @Test

--- a/src/test/java/edu/ksu/canvas/attendance/controller/StudentSummaryControllerITest.java
+++ b/src/test/java/edu/ksu/canvas/attendance/controller/StudentSummaryControllerITest.java
@@ -105,7 +105,7 @@ public class StudentSummaryControllerITest extends BaseControllerITest {
         Long studentId = existingStudent.getStudentId();
         String nonNumberSectionId = "Numbers";
         mockMvc.perform(get("/studentSummary/" + nonNumberSectionId + "/" + studentId))
-            .andExpect(view().name("forward:roster"));
+            .andExpect(view().name("forward:/roster"));
 
     }
 
@@ -115,7 +115,7 @@ public class StudentSummaryControllerITest extends BaseControllerITest {
         Long sectionId = existingSection.getCanvasSectionId();
         String nonNumberstudentId = "L33t";
         mockMvc.perform(get("/studentSummary/" + sectionId + "/" + nonNumberstudentId))
-                .andExpect(view().name("forward:roster"));
+                .andExpect(view().name("forward:/roster"));
 
     }
 
@@ -124,7 +124,7 @@ public class StudentSummaryControllerITest extends BaseControllerITest {
         Long sectionId = existingSection.getCanvasSectionId();
         Long nonExistStudentId = -1L;
         mockMvc.perform(get("/studentSummary/" + sectionId + "/" + nonExistStudentId))
-                .andExpect(view().name("forward:roster"));
+                .andExpect(view().name("forward:/roster"));
 
     }
 


### PR DESCRIPTION
Replaces the relative forward string "forward:roster" with the absolute path "forward:/roster"  to prevent the application from incorrectly appending the forward path onto the existing context URI when path parameters are present, avoiding internal server routing errors (500/404) during path validation or missing student lookups.