### PR TITLE
Fix(security): mitigate CVE-2022-22965 and CVE-2018-1273 RCE vulnerab…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -427,6 +427,14 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
+            <dependency>
+                <groupId>org.springframework.data</groupId>
+                <artifactId>spring-data-releasetrain</artifactId>
+                <version>Ingalls-SR11</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+            <!-- spring-data-commons version is managed by the Spring Boot parent BOM -->
         </dependencies>
     </dependencyManagement>
 

--- a/src/main/java/edu/ksu/canvas/attendance/controller/Spring4ShellMitigationController.java
+++ b/src/main/java/edu/ksu/canvas/attendance/controller/Spring4ShellMitigationController.java
@@ -1,0 +1,27 @@
+package edu.ksu.canvas.attendance.controller;
+
+import org.springframework.web.bind.WebDataBinder;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.InitBinder;
+
+/**
+ * Mitigate CVE-2022-22965 (Spring4Shell) by blocking dangerous data-binding field patterns.
+ */
+@ControllerAdvice
+public class Spring4ShellMitigationController {
+
+    @InitBinder
+    public void initBinder(WebDataBinder binder) {
+        binder.setDisallowedFields(
+                "class.*",
+                "*.class.*",
+                "classLoader.*",
+                "*.classLoader.*",
+                "*.request.*",
+                "*.session.*",
+                "*.application.*",
+                "*[*#*]*", 
+                "*[T(*]*"
+        );
+    }
+}


### PR DESCRIPTION
…ilities.

-Mitigate CVE-2022-22965 (Spring4Shell). By implementing a global  `@ControllerAdvice` , pattern-blocking workaround via ControllerAdvice was chosen over a framework upgrade to Spring 5.3.18+ to maintain environmental compatibility with the application's legacy Spring Boot 1.2.x/Spring 4.3.x deployment topology, providing immediate virtual patching without introducing breaking framework changes.Since `spring-data-commons` is a transitive dependency used across multiple components, explicitly forcing its numeric version would cause a dependency mismatch with other modules .Upgrading the aggregate `spring-data-releasetrain` BOM to `Ingalls-SR11` allows the entire sub-module to build, while preserving class-path harmony.