### PR TITLE
Temporary Solution: Sanitize Content-Disposition headers.

### DIFF
--- a/src/main/java/edu/ksu/canvas/attendance/filter/ContentDispositionSanitizingFilter.java
+++ b/src/main/java/edu/ksu/canvas/attendance/filter/ContentDispositionSanitizingFilter.java
@@ -1,0 +1,101 @@
+package edu.ksu.canvas.attendance.filter;
+
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletResponseWrapper;
+import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Sanitizes Content-Disposition headers to reduce the attack surface for CVE-2020-5421.
+ */
+@Component
+@Order(1)
+public class ContentDispositionSanitizingFilter implements Filter {
+
+    private static final Pattern FILENAME_PATTERN = Pattern.compile("(?i)(filename\\*?=)(\\\"?)([^\\\";]*)(\\\"?)");
+
+    @Override
+    public void init(FilterConfig filterConfig) {
+        // No initialization needed.
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        if (!(response instanceof HttpServletResponse)) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        HttpServletResponse httpResponse = (HttpServletResponse) response;
+        chain.doFilter(request, new HeaderSanitizingResponse(httpResponse));
+    }
+
+    @Override
+    public void destroy() {
+        // No cleanup required.
+    }
+
+    private static class HeaderSanitizingResponse extends HttpServletResponseWrapper {
+
+        HeaderSanitizingResponse(HttpServletResponse response) {
+            super(response);
+        }
+
+        @Override
+        public void setHeader(String name, String value) {
+            super.setHeader(name, sanitizeHeader(name, value));
+        }
+
+        @Override
+        public void addHeader(String name, String value) {
+            super.addHeader(name, sanitizeHeader(name, value));
+        }
+
+        private String sanitizeHeader(String name, String value) {
+            if (value == null || !"Content-Disposition".equalsIgnoreCase(name)) {
+                return value;
+            }
+            return sanitizeContentDisposition(value);
+        }
+
+        private String sanitizeContentDisposition(String contentDisposition) {
+            Matcher matcher = FILENAME_PATTERN.matcher(contentDisposition);
+            StringBuffer replaced = new StringBuffer();
+            while (matcher.find()) {
+                String prefix = matcher.group(1);
+                String quote = matcher.group(2);
+                String filename = matcher.group(3);
+                String sanitizedFilename = sanitizeFilename(filename);
+                matcher.appendReplacement(replaced, prefix + quote + sanitizedFilename + quote);
+            }
+            matcher.appendTail(replaced);
+            return replaced.toString();
+        }
+
+        private String sanitizeFilename(String filename) {
+            if (filename == null) {
+                return filename;
+            }
+            String sanitized = filename.replaceAll("[\\\\/\\r\\n\\t\\u0000\"<>|;]+", "_");
+            sanitized = sanitized.replaceAll("\\.{2,}", ".");
+            if (sanitized.startsWith(".")) {
+                sanitized = sanitized.substring(1);
+            }
+            if (sanitized.isEmpty() || sanitized.matches("_+")) {
+                sanitized = "download";
+            }
+            return sanitized;
+        }
+    }
+}

--- a/src/test/java/edu/ksu/canvas/attendance/filter/ContentDispositionSanitizingFilterUTest.java
+++ b/src/test/java/edu/ksu/canvas/attendance/filter/ContentDispositionSanitizingFilterUTest.java
@@ -1,0 +1,94 @@
+package edu.ksu.canvas.attendance.filter;
+
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class ContentDispositionSanitizingFilterUTest {
+
+    @Test
+    public void sanitizeContentDispositionRemovesPathTraversalFromFilename() throws Exception {
+        assertSanitizedHeader(
+                "Content-Disposition",
+                "attachment; filename=\"../../evil.csv\"",
+                "attachment; filename=\"_._evil.csv\"");
+    }
+
+    @Test
+    public void sanitizeContentDispositionRemovesCrLfInjection() throws Exception {
+        assertSanitizedHeader(
+                "Content-Disposition",
+                "attachment; filename=\"test\r\nX-Injected: yes\"",
+                "attachment; filename=\"test_X-Injected: yes\"");
+    }
+
+    @Test
+    public void sanitizeContentDispositionRemovesNullBytesFromFilename() throws Exception {
+        assertSanitizedHeader(
+                "Content-Disposition",
+                "attachment; filename=\"test\u0000.csv\"",
+                "attachment; filename=\"test_.csv\"");
+    }
+
+    @Test
+    public void sanitizeContentDispositionHandlesQuoteSemicolonBreakout() throws Exception {
+        assertSanitizedHeader(
+                "Content-Disposition",
+                "attachment; filename=\"test\"; evil=1",
+                "attachment; filename=\"test\"; evil=1");
+    }
+
+    @Test
+    public void sanitizeContentDispositionFallsBackToDownloadWhenFilenameIsEmptyAfterSanitization() throws Exception {
+        assertSanitizedHeader(
+                "Content-Disposition",
+                "attachment; filename=\"////\"",
+                "attachment; filename=\"download\"");
+    }
+
+    @Test
+    public void sanitizeContentDispositionIsCaseInsensitiveForHeaderName() throws Exception {
+        assertSanitizedHeader(
+                "content-disposition",
+                "attachment; filename=\"report.csv\"",
+                "attachment; filename=\"report.csv\"");
+    }
+
+    @Test
+    public void sanitizeContentDispositionPreservesValidFilename() throws Exception {
+        assertSanitizedHeader(
+                "Content-Disposition",
+                "attachment; filename=\"report.csv\"",
+                "attachment; filename=\"report.csv\"");
+    }
+
+    private void assertSanitizedHeader(String headerName, String originalValue, String expectedValue) throws Exception {
+        ContentDispositionSanitizingFilter filter = new ContentDispositionSanitizingFilter();
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        ServletRequest request = mock(ServletRequest.class);
+        FilterChain chain = mock(FilterChain.class);
+
+        doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) {
+                HttpServletResponse wrappedResponse = (HttpServletResponse) invocation.getArguments()[1];
+                wrappedResponse.setHeader(headerName, originalValue);
+                return null;
+            }
+        }).when(chain).doFilter(any(ServletRequest.class), any(ServletResponse.class));
+
+        filter.doFilter(request, response, chain);
+
+        verify(response).setHeader(headerName, expectedValue);
+    }
+}


### PR DESCRIPTION
In order to prevent malicious  filtration, a servlet filter that wraps outgoing responses and strips dangerous characters was created. This is a defense-in-depth measure related to CVE-2020-5421 (Spring RFD protection bypass). No currently vulnerable filename-injection point was found in this codebase (AttendanceSummaryController's CSV export uses a hardcoded filename), but this gives a temporary slution to keep security in order.