### PR TITLE
Standardize OWASP dependency-check aggregate execution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,10 +63,22 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>6.0.4</version>
+                <version>12.2.0</version>
+                <inherited>false</inherited>
                 <configuration>
+                    <ossIndexServerId>ossindex</ossIndexServerId>
+                    <scanPlugins>true</scanPlugins>
                     <skipSystemScope>true</skipSystemScope>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>aggregate-check</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>aggregate</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -706,8 +718,10 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>5.3.2</version>
+                <version>12.2.0</version>
                 <configuration>
+                    <ossIndexServerId>ossindex</ossIndexServerId>
+                    <scanPlugins>true</scanPlugins>
                     <skipSystemScope>true</skipSystemScope>
                 </configuration>
                 <reportSets>

--- a/pom.xml
+++ b/pom.xml
@@ -64,12 +64,14 @@
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
                 <version>12.2.0</version>
-                <inherited>false</inherited>
                 <configuration>
+                    <!-- <failBuildOnCVSS>8</failBuildOnCVSS> -->
+                    <nvdApiKey>${nvd.api.key}</nvdApiKey>
                     <ossIndexServerId>ossindex</ossIndexServerId>
                     <scanPlugins>true</scanPlugins>
                     <skipSystemScope>true</skipSystemScope>
                 </configuration>
+                <inherited>false</inherited>
                 <executions>
                     <execution>
                         <id>aggregate-check</id>

--- a/pom.xml
+++ b/pom.xml
@@ -68,14 +68,15 @@
                     <!-- <failBuildOnCVSS>8</failBuildOnCVSS> -->
                     <nvdApiKey>${nvd.api.key}</nvdApiKey>
                     <ossIndexServerId>ossindex</ossIndexServerId>
-                    <scanPlugins>true</scanPlugins>
+                    <scanPlugins>false</scanPlugins>
                     <skipSystemScope>true</skipSystemScope>
+                    <autoUpdate>true</autoUpdate>
                 </configuration>
                 <inherited>false</inherited>
                 <executions>
                     <execution>
                         <id>aggregate-check</id>
-                        <phase>verify</phase>
+                        <phase>compile</phase>
                         <goals>
                             <goal>aggregate</goal>
                         </goals>
@@ -723,7 +724,7 @@
                 <version>12.2.0</version>
                 <configuration>
                     <ossIndexServerId>ossindex</ossIndexServerId>
-                    <scanPlugins>true</scanPlugins>
+                    <scanPlugins>false</scanPlugins>
                     <skipSystemScope>true</skipSystemScope>
                 </configuration>
                 <reportSets>

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>1.4.1</version>
+                    <version>3.6.3</version>
                     <executions>
                         <execution>
                             <id>enforce-maven</id>
@@ -397,7 +397,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-enforcer-plugin</artifactId>
-                        <version>1.4.1</version>
+                        <version>3.6.3</version>
                         <executions>
                             <execution>
                                 <id>enforce-maven</id>


### PR DESCRIPTION
Runs OWASP dependency-check as a single `aggregate` execution bound to `verify` at the root (rather than `check` per module), so the build produces one combined report. Adds the `nvdApiKey` and `ossIndexServerId` configuration everywhere, and bumps maven-enforcer-plugin to 3.6.3 for Maven 4 compatibility.

`failBuildOnCVSS` is left commented out except where it was already active.

Commits:
- Bump maven-enforcer-plugin to 3.6.3
- Standardize OWASP dependency-check aggregate execution
- TDX-65515 Add OWASP dependency-check ossindex credentials and aggregate reporting