### PR TITLE
Adressed Jackson databind CVEs

### DIFF
--- a/.project
+++ b/.project
@@ -51,4 +51,15 @@
 		<nature>org.zeroturnaround.eclipse.jrebelNature</nature>
 		<nature>org.zeroturnaround.eclipse.remoting.remotingNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1787942609805</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/src/main/java/edu/ksu/canvas/attendance/config/AppConfig.java
+++ b/src/main/java/edu/ksu/canvas/attendance/config/AppConfig.java
@@ -20,6 +20,16 @@ import org.springframework.web.servlet.view.UrlBasedViewResolver;
 import java.util.List;
 
 
+/**
+ * Main application configuration.
+ * 
+ * Security Notes:
+ * - Jackson is configured in JacksonConfig with defensive settings against:
+ *   - CVE-2020-36518: Deeply nested JSON causing stack overflow (DoS)
+ *   - CVE-2022-42003: UNWRAP_SINGLE_VALUE_ARRAYS unbounded resource consumption
+ *   - CVE-2022-42004: BeanDeserializer._deserialize unbounded resource consumption
+ * - Jackson version 2.17.1 includes patches for these vulnerabilities
+ */
 @Configuration
 @EnableAutoConfiguration
 @EnableWebMvcSecurity

--- a/src/main/java/edu/ksu/canvas/attendance/config/JacksonConfig.java
+++ b/src/main/java/edu/ksu/canvas/attendance/config/JacksonConfig.java
@@ -1,0 +1,47 @@
+package edu.ksu.canvas.attendance.config;
+
+import com.fasterxml.jackson.core.StreamReadConstraints;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration for Jackson ObjectMapper with defensive settings against CVEs:
+ * - CVE-2020-36518: Deeply nested JSON objects causing stack overflow (DoS)
+ * - CVE-2022-42003: JSON objects exploiting UNWRAP_SINGLE_VALUE_ARRAYS with unbounded resource consumption
+ * - CVE-2022-42004: BeanDeserializer._deserialize with unbounded resource consumption
+ * 
+ * These security measures are applied even though Jackson 2.17.1 is already patched.
+ * The defensive configuration provides additional protection against potential bypasses.
+ * 
+ * Note: Spring Boot 1.2.8 doesn't support Jackson2ObjectMapperBuilderCustomizer (added in 1.4+),
+ * so this uses direct ObjectMapper bean configuration instead.
+ */
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+
+        // Disable features that can be exploited
+        mapper.disable(DeserializationFeature.UNWRAP_SINGLE_VALUE_ARRAYS);
+        mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+        // Apply streaming constraints to limit nesting depth and string/number lengths
+        // This provides defense-in-depth for:
+        // - CVE-2020-36518: Limits nesting depth to prevent stack overflow
+        // - CVE-2022-42003 & CVE-2022-42004: Limits resource consumption
+        mapper.getFactory().setStreamReadConstraints(
+            StreamReadConstraints.builder()
+                .maxNestingDepth(200)              // Prevent stack overflow from deep nesting
+                .maxNumberLength(100)              // Prevent resource exhaustion from large numbers
+                .maxStringLength(5_000_000)        // Limit individual strings to 5MB
+                .build()
+        );
+
+        return mapper;
+    }
+}
+

--- a/src/test/java/edu/ksu/canvas/attendance/config/JacksonConfigUTest.java
+++ b/src/test/java/edu/ksu/canvas/attendance/config/JacksonConfigUTest.java
@@ -1,0 +1,159 @@
+package edu.ksu.canvas.attendance.config;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for JacksonConfig to verify CVE mitigation security settings.
+ * 
+ * Tests verify:
+ * - CVE-2020-36518: Deeply nested JSON protection
+ * - CVE-2022-42003: UNWRAP_SINGLE_VALUE_ARRAYS disabled
+ * - CVE-2022-42004: Resource consumption limits
+ */
+public class JacksonConfigUTest {
+
+    private JacksonConfig jacksonConfig;
+    private ObjectMapper objectMapper;
+
+    @Before
+    public void setUp() {
+        jacksonConfig = new JacksonConfig();
+        objectMapper = jacksonConfig.objectMapper();
+    }
+
+    @Test
+    public void testObjectMapperBeanIsCreated() {
+        assertNotNull("ObjectMapper bean should be created", objectMapper);
+    }
+
+    @Test
+    public void testUnwrapSingleValueArraysIsDisabled() {
+        assertFalse("UNWRAP_SINGLE_VALUE_ARRAYS should be disabled",
+                objectMapper.isEnabled(DeserializationFeature.UNWRAP_SINGLE_VALUE_ARRAYS));
+    }
+
+    @Test
+    public void testFailOnUnknownPropertiesIsDisabled() {
+        assertFalse("FAIL_ON_UNKNOWN_PROPERTIES should be disabled",
+                objectMapper.isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES));
+    }
+
+    @Test
+    public void testStreamReadConstraintsAreConfigured() {
+        JsonFactory factory = objectMapper.getFactory();
+        assertNotNull("JsonFactory should have StreamReadConstraints configured", factory);
+    }
+
+    @Test
+    public void testMaxNestingDepthConstraint() {
+        StringBuilder deepJson = new StringBuilder();
+        for (int i = 0; i < 201; i++) {
+            deepJson.append("{\"a\":");
+        }
+        deepJson.append("1");
+        for (int i = 0; i < 201; i++) {
+            deepJson.append("}");
+        }
+        
+        try {
+            objectMapper.readValue(deepJson.toString(), Object.class);
+            fail("Should have rejected JSON with nesting depth > 200 (CVE-2020-36518)");
+        } catch (Exception e) {
+            assertNotNull("Expected a Jackson exception for excessive nesting", e);
+        }
+    }
+
+    @Test
+    public void testMaxNumberLengthConstraint() {
+        StringBuilder longNumber = new StringBuilder();
+        for (int i = 0; i < 101; i++) {
+            longNumber.append("9");
+        }
+        String json = "{\"number\": " + longNumber.toString() + "}";
+        
+        try {
+            objectMapper.readValue(json, Object.class);
+            fail("Should have rejected number with length > 100 (CVE-2022-42004)");
+        } catch (Exception e) {
+            assertNotNull("Expected a Jackson exception for overly long number", e);
+        }
+    }
+
+    @Test
+    public void testMaxStringLengthConstraint() {
+        StringBuilder longString = new StringBuilder();
+        for (int i = 0; i < 5_000_001; i++) {
+            longString.append("a");
+        }
+        String json = "{\"string\": \"" + longString.toString() + "\"}";
+        
+        try {
+            objectMapper.readValue(json, Object.class);
+            fail("Should have rejected string with length > 5MB (CVE-2022-42004)");
+        } catch (Exception e) {
+            assertNotNull("Expected a Jackson exception for oversized string", e);
+        }
+    }
+
+    @Test
+    public void testValidJsonIsAccepted() throws Exception {
+        String validJson = "{\"name\": \"test\", \"age\": 30}";
+        Object result = objectMapper.readValue(validJson, Object.class);
+        assertNotNull("Valid JSON should be successfully deserialized", result);
+    }
+
+    @Test
+    public void testModerateNestingDepthIsAccepted() throws Exception {
+        StringBuilder moderateJson = new StringBuilder();
+        for (int i = 0; i < 100; i++) {
+            moderateJson.append("{\"a\":");
+        }
+        moderateJson.append("1");
+        for (int i = 0; i < 100; i++) {
+            moderateJson.append("}");
+        }
+        
+        Object result = objectMapper.readValue(moderateJson.toString(), Object.class);
+        assertNotNull("JSON with nesting depth within limit should be accepted", result);
+    }
+
+    @Test
+    public void testValidNumberIsAccepted() throws Exception {
+        String json = "{\"number\": 123456789}";
+        Object result = objectMapper.readValue(json, Object.class);
+        assertNotNull("Valid number should be accepted", result);
+    }
+
+    @Test
+    public void testValidStringIsAccepted() throws Exception {
+        StringBuilder validString = new StringBuilder();
+        for (int i = 0; i < 1000; i++) {
+            validString.append("a");
+        }
+        String json = "{\"string\": \"" + validString.toString() + "\"}";
+        
+        Object result = objectMapper.readValue(json, Object.class);
+        assertNotNull("Valid string within size limit should be accepted", result);
+    }
+
+    @Test
+    public void testMultipleConstraintsWork() throws Exception {
+        String validJson = "{\"nested\": {\"value\": 42, \"text\": \"hello\"}}";
+        Object result = objectMapper.readValue(validJson, Object.class);
+        assertNotNull("Multiple constraints should not affect valid JSON", result);
+    }
+
+    @Test
+    public void testUnknownPropertiesAreIgnored() throws Exception {
+        String jsonWithUnknown = "{\"name\": \"test\", \"unknownField\": \"value\"}";
+        Object result = objectMapper.readValue(jsonWithUnknown, Object.class);
+        assertNotNull("JSON with unknown properties should be accepted", result);
+    }
+
+}


### PR DESCRIPTION
Added defensive Jacson ObjectMapper Configuration, enforce max nesting  and added a UTest for the added confiigurations. his addresses the Jackson databind CVEs including:

CVE-2020-36518
CVE-2022-42003
CVE-2022-42004