### PR TITLE
Fix unsafe  casting and remove deprecated Long() usage.

### DIFF
--- a/src/main/java/edu/ksu/canvas/attendance/controller/MakeupController.java
+++ b/src/main/java/edu/ksu/canvas/attendance/controller/MakeupController.java
@@ -67,8 +67,8 @@ public class MakeupController extends AttendanceBaseController {
             return new ModelAndView("forward:roster/"+validatedSectionId);
         }
 
-        AttendanceStudent student = studentService.getStudent(new Long(studentId));
-        MakeupForm makeupForm = makeupService.createMakeupForm(Long.valueOf(studentId), Long.valueOf(sectionId), addEmptyEntry);
+        AttendanceStudent student = selectedStudent;
+        MakeupForm makeupForm = makeupService.createMakeupForm(validatedStudentId.longValue(), validatedSectionId.longValue(), addEmptyEntry);
 
         ModelAndView page = new ModelAndView("studentMakeup");
         page.addObject("sectionId", sectionId);

--- a/src/main/java/edu/ksu/canvas/attendance/repository/AttendanceRepositoryImpl.java
+++ b/src/main/java/edu/ksu/canvas/attendance/repository/AttendanceRepositoryImpl.java
@@ -8,6 +8,8 @@ import javax.persistence.*;
 import javax.transaction.Transactional;
 import java.util.*;
 import java.util.stream.Collectors;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 
 @Repository
@@ -17,6 +19,8 @@ public class AttendanceRepositoryImpl implements AttendanceRepositoryCustom {
 
     @PersistenceContext
     private EntityManager entityManager;
+
+    private static final Logger LOG = LogManager.getLogger(AttendanceRepositoryImpl.class);
 
 
     /**
@@ -50,12 +54,18 @@ public class AttendanceRepositoryImpl implements AttendanceRepositoryCustom {
                     "FROM Attendance att " +
                     "WHERE att.notes IS NOT NULL AND att.attendanceStudent.canvasSectionId = :canvasSectionId ";
 
-        Query query = entityManager.createQuery(jpql);
+        TypedQuery<AttendanceCommentEntry> query = entityManager.createQuery(jpql, AttendanceCommentEntry.class);
         query.setParameter("canvasSectionId", sectionId);
 
-        List<AttendanceCommentEntry> results = (List<AttendanceCommentEntry>) query.getResultList();
+        List<AttendanceCommentEntry> results;
+        try {
+            results = query.getResultList();
+        } catch (PersistenceException | ClassCastException e) {
+            LOG.error("Error executing attendance comments query for sectionId {}", sectionId, e);
+            return Collections.emptyMap();
+        }
 
-        return groupCommentsByStudents(results);
+        return groupCommentsByStudents(results == null ? Collections.emptyList() : results);
     }
 
     /**

--- a/src/main/java/edu/ksu/canvas/attendance/services/MakeupService.java
+++ b/src/main/java/edu/ksu/canvas/attendance/services/MakeupService.java
@@ -29,7 +29,7 @@ public class MakeupService {
      * @throws IllegalArgumentException when a student cannot be found in the database for the given studentId
      */
     public MakeupForm createMakeupForm(long studentId, long sectionId, boolean addEmptyEntry) {
-        AttendanceStudent student = attendanceStudentRepository.findByStudentId(new Long(studentId));
+        AttendanceStudent student = attendanceStudentRepository.findByStudentId(Long.valueOf(studentId));
         if(student == null) {
             RuntimeException e = new IllegalArgumentException("student does not exist in the database");
             throw new ContextedRuntimeException(e).addContextValue("studentId", studentId);

--- a/src/test/java/edu/ksu/canvas/attendance/repository/AttendanceRepositoryImplUTest.java
+++ b/src/test/java/edu/ksu/canvas/attendance/repository/AttendanceRepositoryImplUTest.java
@@ -4,37 +4,58 @@ import edu.ksu.canvas.attendance.entity.Attendance;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceException;
+import javax.persistence.TypedQuery;
+import java.util.Arrays;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
 
 
 @RunWith(MockitoJUnitRunner.class)
 public class AttendanceRepositoryImplUTest {
 
+    @Mock
+    private EntityManager entityManager;
+
+    @Mock
+    private TypedQuery<AttendanceCommentEntry> attendanceCommentEntryQuery;
+
     private AttendanceRepositoryImpl attendanceRepository;
-    
-    
+
+
     @Before
     public void setup() {
         attendanceRepository = new AttendanceRepositoryImpl();
+        ReflectionTestUtils.setField(attendanceRepository, "entityManager", entityManager);
     }
-    
-    
+
+
     @Test(expected=NullPointerException.class)
     public void getAttendanceByCourseAndDayOfClass_NullDateOfClass() {
         int irrelevantCourseId = 2;
         Date nullDateOfClass = null;
-        
+
         attendanceRepository.getAttendanceByCourseAndDayOfClass(irrelevantCourseId, nullDateOfClass);
     }
-    
-    
+
+
     @Test
     public void saveInBatches_tollerateNullAttendances() {
         List<Attendance> nullAttendances = null;
-        
+
         attendanceRepository.saveInBatches(nullAttendances);
     }
 
@@ -47,4 +68,44 @@ public class AttendanceRepositoryImplUTest {
         attendanceRepository.deleteAttendanceByCourseAndDayOfClass(irrelevantCourseId, nullDateOfClass, irrelevantSectionId);
     }
 
+    @Test
+    public void getAttendanceCommentsBySectionId_groupsCommentsByStudent() {
+        long sectionId = 101L;
+        Date firstDate = date(2024, Calendar.JANUARY, 15);
+        Date secondDate = date(2024, Calendar.JANUARY, 16);
+
+        when(entityManager.createQuery(anyString(), eq(AttendanceCommentEntry.class)))
+                .thenReturn(attendanceCommentEntryQuery);
+        when(attendanceCommentEntryQuery.getResultList()).thenReturn(Arrays.asList(
+                new AttendanceCommentEntry(42L, firstDate, "First comment"),
+                new AttendanceCommentEntry(42L, secondDate, "Second comment"),
+                new AttendanceCommentEntry(7L, firstDate, "Other student comment")
+        ));
+
+        Map<Long, String> commentsByStudent = attendanceRepository.getAttendanceCommentsBySectionId(sectionId);
+
+        assertEquals(2, commentsByStudent.size());
+        assertEquals("01/15/2024: First comment\n01/16/2024: Second comment\n", commentsByStudent.get(42L));
+        assertEquals("01/15/2024: Other student comment\n", commentsByStudent.get(7L));
+    }
+
+    @Test
+    public void getAttendanceCommentsBySectionId_returnsEmptyMapWhenQueryFails() {
+        long sectionId = 202L;
+
+        when(entityManager.createQuery(anyString(), eq(AttendanceCommentEntry.class)))
+                .thenReturn(attendanceCommentEntryQuery);
+        when(attendanceCommentEntryQuery.getResultList()).thenThrow(new PersistenceException("query failed"));
+
+        Map<Long, String> commentsByStudent = attendanceRepository.getAttendanceCommentsBySectionId(sectionId);
+
+        assertTrue(commentsByStudent.isEmpty());
+    }
+
+    private Date date(int year, int month, int dayOfMonth) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.clear();
+        calendar.set(year, month, dayOfMonth);
+        return calendar.getTime();
+    }
 }


### PR DESCRIPTION
Replace unsafe raw cast in AttendanceRepositoryImpl.getAttendanceCommentsBySectionId with a typed TypedQuery<AttendanceCommentEntry> .Add graceful exception handling/logging for query failures. Replace deprecated new Long(...) usages with Long.valueOf(...) and validated Long handling in makeup flows.